### PR TITLE
Fix typo from 'enterprice' to 'enterprise'

### DIFF
--- a/src/AppBundle/Resources/views/Home/homepage.html.twig
+++ b/src/AppBundle/Resources/views/Home/homepage.html.twig
@@ -52,7 +52,7 @@
   <blockquote>
     <div class="row">
       <div class="col-sm-offset-4 col-sm-6 text-right">
-        <p>it is not big enough for Deathstar enterprice software and it does not run on Windows!?</p>
+        <p>it is not big enough for Deathstar enterprise software and it does not run on Windows!?</p>
         <small>Darth Vader</small>
       </div>
       <div class="col-sm-2 text-center">


### PR DESCRIPTION
Small grammar nazi outbreak
